### PR TITLE
Use the correct key for specifying the zone-name.

### DIFF
--- a/bigv-vm
+++ b/bigv-vm
@@ -139,7 +139,7 @@ def main():
                                                  cores=module.params['vm_cores'],
                                                  memory=module.params['vm_memory'],
                                                  discs=module.params['vm_discs'],
-                                                 zone_name=module.params['vm_zone_name'],
+                                                 zone_name=module.params['vm_zone'],
                                                  root_password=module.params['vm_root_password'])
                 #
                 # Poll to see if the machine has been switched on (wait for 5 minutes)


### PR DESCRIPTION
In the rest of the code we use "bigv_zone" to specify the
(optional) zone-name to use when creating virtual machines.  In
the provisioning setup though we use "bigv_zone_name", which causes
the following error:

      File "/home/steve/.ansible/tmp/ansible-tmp-x-y/bigv-vm",
        line 142, in main
            zone_name=module.params['vm_zone_name'],
            KeyError: 'vm_zone_name'

Renaming the key from `vm_zone_name` to `vm_zone` resolves the
problem.